### PR TITLE
Add Target Framework netstandard2.0

### DIFF
--- a/src/Markdig.Renderers.Docx.Tests/Markdig.Renderers.Docx.Tests.csproj
+++ b/src/Markdig.Renderers.Docx.Tests/Markdig.Renderers.Docx.Tests.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DocumentFormat.OpenXml" Version="2.15.0" />
+        <PackageReference Include="DocumentFormat.OpenXml" Version="2.18.0" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/src/Markdig.Renderers.Docx/DocxDocumentRenderer.cs
+++ b/src/Markdig.Renderers.Docx/DocxDocumentRenderer.cs
@@ -90,7 +90,7 @@ public class DocxDocumentRenderer : RendererBase
         }
     }
 
-    public override DocxDocumentRenderer Render(MarkdownObject markdownObject)
+    public override object Render(MarkdownObject markdownObject)
     {
         if (markdownObject is MarkdownDocument)
         {

--- a/src/Markdig.Renderers.Docx/Markdig.Renderers.Docx.csproj
+++ b/src/Markdig.Renderers.Docx/Markdig.Renderers.Docx.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+        <LangVersion>Latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -20,8 +21,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="DocumentFormat.OpenXml" Version="2.15.0" />
-      <PackageReference Include="Markdig" Version="0.27.0" />
+      <PackageReference Include="DocumentFormat.OpenXml" Version="2.18.0" />
+      <PackageReference Include="Markdig" Version="0.33.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     </ItemGroup>
 

--- a/src/Markdig.Renderers.Docx/Polyfills/NetStandard20Polyfills.cs
+++ b/src/Markdig.Renderers.Docx/Polyfills/NetStandard20Polyfills.cs
@@ -1,0 +1,34 @@
+﻿namespace Markdig.Renderers.Docx;
+
+internal static class NetStandard20Polyfills
+{
+    public static TValue GetValueOrDefault<TKey, TValue>(
+        this IReadOnlyDictionary<TKey, TValue> target,
+        TKey key,
+        TValue defaultValue = default!)
+    {
+        if (target.TryGetValue(key, out var result))
+        {
+            return result!;
+        }
+
+        return defaultValue;
+    }
+
+    public static bool TryPeek<T>(this Stack<T> stack, out T result)
+    {
+        if (stack.Count == 0)
+        {
+            result = default!;
+            return false;
+        }
+
+        result = stack.Peek();
+        return true;
+    }
+
+    public static string[] Split(this string str, string separator, StringSplitOptions options = StringSplitOptions.None)
+    {
+        return str.Split(separator.ToCharArray(), options);
+    }
+}


### PR DESCRIPTION
Add support for .NET Framework and .NET Core
- Add Target Framework netstandard2.0
- Upgrade package DocumentFormat.OpenXml to 2.18.0
- Upgrade package Markdig to 0.33.0